### PR TITLE
Removing hardcoded path to script

### DIFF
--- a/pmb-pitft/pitft_ui.py
+++ b/pmb-pitft/pitft_ui.py
@@ -20,7 +20,7 @@ class PmbPitft:
 
 		# Paths
 		self.path = os.path.dirname(sys.argv[0]) + "/"
-    os.chdir(self.path)
+		os.chdir(self.path)
 		
 		# Fonts
 		self.fontfile = self.path + "helvetica-neue-bold.ttf"


### PR DESCRIPTION
- Path for pmb-pitft no longer hardcoded 
- Script can now be started outside of its folder
